### PR TITLE
Updated primary language to Python

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We have some general coding guidelines to help ensure consistency in our project
 
 ### Languages
 
-*Lua*
+*Python*
 
 ## Pull Requests
 


### PR DESCRIPTION
The Language in the Contributor.md file will now reference Python as the primary language as opposed to Lua.

Closes #4 